### PR TITLE
Fix AP round gui flash on screen top middle

### DIFF
--- a/DboClient/Client/Gui/HpGui.cpp
+++ b/DboClient/Client/Gui/HpGui.cpp
@@ -762,7 +762,6 @@ VOID CHpGui::SetMaxRPBall( RwInt32 nMaxRPBall )
 void CHpGui::SetAirGuiPosition()
 {
 	m_surMidAir.SetPosition(m_psttAirPoint->GetScreenRect().left + 8.5, (m_psttAirPoint->GetScreenRect().bottom / 2) - 7);
-	m_rRoundAir.SetPosition(m_ppnlAirPoint->GetScreenRect().left + 3, m_ppnlAirPoint->GetScreenRect().top + 4);
 }
 
 void CHpGui::UpdateAir()
@@ -780,6 +779,7 @@ void CHpGui::UpdateAir()
 	}
 
 	SetAirGuiPosition();
+	m_rRoundAir.SetPosition(m_ppnlAirPoint->GetScreenRect().left + 3, m_ppnlAirPoint->GetScreenRect().top + 4);
 
 	if (m_bIsWorldAirPossible)
 	{


### PR DESCRIPTION
Fix the AP round gui flash issue (last time is middle gui flash).
Now it should be no flash in whole AP gui system.