### PR TITLE
GUI party bug. & RP charge effect bug when pressing log out.

### DIFF
--- a/DboClient/Client/Gui/PartyMemberGui.h
+++ b/DboClient/Client/Gui/PartyMemberGui.h
@@ -45,6 +45,7 @@ public:
 
 	VOID		Show(bool bShow);
 	VOID		SetPosition(RwInt32 iXPos, RwInt32 iYPos);
+	CBuffDispGui* GetBuffsDispGui() { return m_pBuff; }; //EXPORT BUFF DISP GUI
 
 protected:
 	VOID		HandleEvents(RWS::CMsg &pMsg);	
@@ -73,6 +74,7 @@ public:
 	RwBool		Create(SERIAL_HANDLE hSerial, WCHAR* pcText, RwUInt8 byClass);
 	VOID		Update(RwReal fElapsed);
 	VOID		Destroy();
+	CPartyMemberBuffGui* GetBuffsGui() { return m_pBuff; }; //Export BUFF GUI
 
 	SERIAL_HANDLE GetHandle();						///< 맴버의 핸들 반환
 

--- a/DboClient/Client/Gui/PartyMenuGui.cpp
+++ b/DboClient/Client/Gui/PartyMenuGui.cpp
@@ -30,6 +30,11 @@
 #include "SideDialogManager.h"
 #include "PopupManager.h"
 
+//party
+#include "PartyMemberGui.h"
+#include "BuffDispObject.h"
+#include "PartyMemberGui.h"
+
 namespace
 {
 	#define dMENU_GAP					26
@@ -247,12 +252,25 @@ VOID CPartyMenu::DelMember(SERIAL_HANDLE hSerial)
 		}
 	}
 
-	// 삭제된 맴버ui 밑의 ui를 한단계씩 위로 올린다.
+	// elevate a member to a higher level gui and update buffs.
+	/*
+	This block ensures that after removing a member from the party,
+	the remaining members are correctly repositioned and their buffs are updated to avoid visual issues.
+	*/
 	for( ; it != m_listPartyMember.end() ; ++it )
 	{
 		pPartyMemberGui = *it;
 		CRectangle rect = pPartyMemberGui->GetPosition();
 		pPartyMemberGui->SetPosition(dDIALOG_CLEINT_EDGE_GAP, rect.top - pPartyMemberGui->GetHeight() - 40);
+		
+		// Get party of player
+		CNtlParty* pParty = GetNtlSLGlobal()->GetSobAvatar()->GetParty();
+
+		// Get the party member using the member's GUI handle (Serial ID)
+		sPartyMember* pMember = reinterpret_cast<sPartyMember*>(pParty->GetMemberbyKey(pPartyMemberGui->GetHandle()));
+		if (pMember) { // If the member exists, update their buffs
+			pPartyMemberGui->GetBuffsGui()->GetBuffsDispGui()->SetBuffAll(pMember->pFakeBuffContainer);
+		}
 	}
 }
 

--- a/DboClient/Lib/NtlSimulation/NtlSobCharProxyDecoration.cpp
+++ b/DboClient/Lib/NtlSimulation/NtlSobCharProxyDecoration.cpp
@@ -90,6 +90,7 @@ CNtlSobCharDecorationProxy::~CNtlSobCharDecorationProxy()
     DeleteTenkaichiMark();
     DeleteTargetMarkingMark();
 	DeletePLPlayerTitle();
+	DeleteRpChargeEffect(); //FIX: RP Charge bug, player leave game.
 	DeleteGuardEffect();
 
     NTL_DELETE(m_pShareTargetMark);


### PR DESCRIPTION
### **The GUI issue when a player leaves the party has been resolved.**
**Bug brief description:** party members with buffs are moved to fill the empty space left by a departing player, causing a screen bug due to the radar effect of each buff's timer.

https://github.com/OpenDBO/OpenDBO-Core/assets/172877648/d2089c12-c67d-44f8-bf9d-65f959ccf06c


### **The RP charge effect bug has been fixed.**
**Bug brief description:** when a player exits to the character selection menu while RP is charging, the effect remains persistent on the map.

https://github.com/OpenDBO/OpenDBO-Core/assets/172877648/24973d52-e99d-4f7e-bea1-2fa5ce566a23

_Credits for the video: deadroseking & Megamood_
