### PR TITLE
fixes potential wrong error notification when deleting mascot

### DIFF
--- a/DboServer/Server/GameServer/CPlayer.cpp
+++ b/DboServer/Server/GameServer/CPlayer.cpp
@@ -3093,7 +3093,7 @@ void CPlayer::DeleteMascot(BYTE byIndex)
 		WORD resultcode = GAME_SUCCESS;
 
 		//Check if pet is summoned
-		if (player_data.mascotTblidx == mascot->GetMascotData()->tblidx)
+		if (GetCurrentMascot() && GetCurrentMascot()->GetMascotData() && GetCurrentMascot()->GetMascotData()->byIndex == byIndex)
 			resultcode = SUMMONING_MASCOT_CANT_DELETE;
 
 		CGameServer* app = (CGameServer*)g_pApp;


### PR DESCRIPTION
This fixes following use case:

So what would happen is for example when you had 4 pets registered.
Now pet in slot 2 is identical (same tblidx) with pet in slot 4. 

User has summoned pet in slot4 and tried to delete pet in slot2.
User would get this wrong error: SUMMONING_MASCOT_CANT_DELETE